### PR TITLE
mark-devkit: Bump dev-vcs/gitg-3.32.1-r1

### DIFF
--- a/dev-vcs/gitg/gitg-3.32.1-r1.ebuild
+++ b/dev-vcs/gitg/gitg-3.32.1-r1.ebuild
@@ -2,7 +2,7 @@
 
 EAPI=7
 PYTHON_COMPAT=( python3+ )
-VALA_MIN_API_VERSION="0.54"
+VALA_MIN_API_VERSION="0.40"
 
 inherit gnome.org gnome3-utils meson python-r1 vala xdg-utils
 
@@ -51,7 +51,6 @@ DEPEND="${RDEPEND}
 
 src_prepare() {
 	default
-	sed -i -e "/  desktop,/d" -e "/  appdata,/d" data/meson.build
 	vala_src_prepare
 	xdg_environment_reset
 }


### PR DESCRIPTION
Automatic bump of package dev-vcs/gitg-3.32.1-r1 for branch mark-iii by mark-bot