### PR TITLE
mark-devkit: Bump gnome-extra/gnome-contacts-3.36.2-r1

### DIFF
--- a/gnome-extra/gnome-contacts/gnome-contacts-3.36.2-r1.ebuild
+++ b/gnome-extra/gnome-contacts/gnome-contacts-3.36.2-r1.ebuild
@@ -52,11 +52,6 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 "
 
-PATCHES=(
-	"${FILESDIR}"/gnome-contacts-3.36.2_22ac2c6fecc98efd11d96dc3e04938b8777a3510.patch
-	"${FILESDIR}"/gnome-contacts-3.36.2_mr109.patch
-)
-
 src_prepare() {
 	vala_src_prepare
 	gnome3_src_prepare


### PR DESCRIPTION
Automatic bump of package gnome-extra/gnome-contacts-3.36.2-r1 for branch mark-iii by mark-bot