### PR TITLE
mark-devkit: Bump gnome-extra/gnome-calculator-3.36.0-r1

### DIFF
--- a/gnome-extra/gnome-calculator/gnome-calculator-3.36.0-r1.ebuild
+++ b/gnome-extra/gnome-calculator/gnome-calculator-3.36.0-r1.ebuild
@@ -3,7 +3,7 @@
 EAPI=7
 inherit gnome3 meson vala
 
-VALA_MAX_API_VERSION=0.54
+VALA_MAX_API_VERSION=0.46
 
 DESCRIPTION="A calculator application for GNOME"
 HOMEPAGE="https://wiki.gnome.org/Apps/Calculator"


### PR DESCRIPTION
Automatic bump of package gnome-extra/gnome-calculator-3.36.0-r1 for branch mark-iii by mark-bot