### PR TITLE
mark-devkit: Bump media-gfx/gnome-photos-3.34.2-r1

### DIFF
--- a/media-gfx/gnome-photos/gnome-photos-3.34.2-r1.ebuild
+++ b/media-gfx/gnome-photos/gnome-photos-3.34.2-r1.ebuild
@@ -1,4 +1,5 @@
 # Distributed under the terms of the GNU General Public License v2
+
 EAPI=7
 PYTHON_COMPAT=( python3+ )
 
@@ -68,7 +69,6 @@ src_prepare() {
 	xdg_src_prepare
 	sed -i -e "/  desktop,/d" -e "/  appdata,/d" data/meson.build
 	sed -i -e "/photos_docdir.*=.*join_paths/s/meson.project_name()/'${PF}'/" meson.build
-	sed -i -e "s|^babl_dep.*|babl_dep = dependency('babl-0.1', 'babl')|g" meson.build
 }
 
 src_configure() {


### PR DESCRIPTION
Automatic bump of package media-gfx/gnome-photos-3.34.2-r1 for branch mark-iii by mark-bot