### PR TITLE
mark-devkit: Bump media-gfx/simple-scan-3.36.6-r1

### DIFF
--- a/media-gfx/simple-scan/simple-scan-3.36.6-r1.ebuild
+++ b/media-gfx/simple-scan/simple-scan-3.36.6-r1.ebuild
@@ -1,7 +1,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-VALA_MAX_API_VERSION=0.54
+VALA_MAX_API_VERSION=0.46
 
 inherit gnome3 vala meson
 


### PR DESCRIPTION
Automatic bump of package media-gfx/simple-scan-3.36.6-r1 for branch mark-unstable by mark-bot