### PR TITLE
mark-devkit: Bump gnome-extra/gnome-clocks-3.36.2-r1

### DIFF
--- a/gnome-extra/gnome-clocks/gnome-clocks-3.36.2-r1.ebuild
+++ b/gnome-extra/gnome-clocks/gnome-clocks-3.36.2-r1.ebuild
@@ -30,10 +30,6 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 "
 
-PATCHES=(
-	"${FILESDIR}"/gnome-clocks-vala-0.54.patch
-)
-
 src_prepare() {
 	vala_src_prepare
 	gnome3_src_prepare


### PR DESCRIPTION
Automatic bump of package gnome-extra/gnome-clocks-3.36.2-r1 for branch mark-unstable by mark-bot