### PR TITLE
mark-devkit: Bump games-board/iagno-3.36.7-r1

### DIFF
--- a/games-board/iagno/iagno-3.36.7-r1.ebuild
+++ b/games-board/iagno/iagno-3.36.7-r1.ebuild
@@ -33,11 +33,7 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 "
 
-PATCHES=(
-	"${FILESDIR}/${PN}-3.35.90-posix.patch"
-	"${FILESDIR}"/iagno_508c0f94e5f182e50ff61be6e04f72574dee97cb.patch
-	"${FILESDIR}"/iagno_e8a0aeec350ea80349582142c0e8e3cd3f1bce38.patch
-)
+PATCHES=( "${FILESDIR}/${PN}-3.35.90-posix.patch" )
 
 src_prepare() {
 	gnome3_src_prepare


### PR DESCRIPTION
Automatic bump of package games-board/iagno-3.36.7-r1 for branch mark-unstable by mark-bot