### PR TITLE
mark-devkit: Bump gnome-extra/gnome-software-3.36.1-r1

### DIFF
--- a/gnome-extra/gnome-software/gnome-software-3.36.1-r1.ebuild
+++ b/gnome-extra/gnome-software/gnome-software-3.36.1-r1.ebuild
@@ -42,9 +42,6 @@ BDEPEND="
 		app-text/docbook-xml-dtd:4.3 )
 "
 # test? ( dev-util/valgrind )
-PATCHES=(
-	"${FILESDIR}"/gnome-software-fwupd2.patch
-)
 
 src_prepare() {
 	xdg_src_prepare


### PR DESCRIPTION
Automatic bump of package gnome-extra/gnome-software-3.36.1-r1 for branch mark-unstable by mark-bot