### PR TITLE
mark-devkit: Bump x11-libs/gtk+-2.24.32-r3

### DIFF
--- a/x11-libs/gtk+/files/patches/0021-gtkcupsutils.patch
+++ b/x11-libs/gtk+/files/patches/0021-gtkcupsutils.patch
@@ -1,0 +1,33 @@
+diff --git a/modules/printbackends/cups/gtkcupsutils.c b/modules/printbackends/cups/gtkcupsutils.c
+index dbf9d51..fdea70d 100644
+--- a/modules/printbackends/cups/gtkcupsutils.c
++++ b/modules/printbackends/cups/gtkcupsutils.c
+@@ -83,28 +83,6 @@ static GtkCupsRequestStateFunc get_states[] = {
+   _get_read_data
+ };
+ 
+-#ifndef HAVE_CUPS_API_1_6
+-#define ippSetOperation(ipp_request, ipp_op_id) ipp_request->request.op.operation_id = ipp_op_id
+-#define ippSetRequestId(ipp_request, ipp_rq_id) ipp_request->request.op.request_id = ipp_rq_id
+-#define ippSetState(ipp_request, ipp_state) ipp_request->state = ipp_state
+-#define ippGetString(attr, index, foo) attr->values[index].string.text
+-#define ippGetCount(attr) attr->num_values
+-
+-int
+-ippSetVersion (ipp_t *ipp,
+-               int    major,
+-               int    minor)
+-{
+-  if (!ipp || major < 0 || minor < 0)
+-    return 0;
+-
+-  ipp->request.any.version[0] = major;
+-  ipp->request.any.version[1] = minor;
+-
+-  return 1;
+-}
+-#endif
+-
+ static void
+ gtk_cups_result_set_error (GtkCupsResult    *result,
+                            GtkCupsErrorType  error_type,

--- a/x11-libs/gtk+/files/patches/0022-gtkprintbackendcups.patch
+++ b/x11-libs/gtk+/files/patches/0022-gtkprintbackendcups.patch
@@ -1,0 +1,145 @@
+diff --git a/modules/printbackends/cups/gtkprintbackendcups.c b/modules/printbackends/cups/gtkprintbackendcups.c
+index 2a000dc..de63c96 100644
+--- a/modules/printbackends/cups/gtkprintbackendcups.c
++++ b/modules/printbackends/cups/gtkprintbackendcups.c
+@@ -265,31 +265,6 @@ pb_module_create (void)
+ {
+   return gtk_print_backend_cups_new ();
+ }
+-/* CUPS 1.6 Getter/Setter Functions CUPS 1.6 makes private most of the
+- * IPP structures and enforces access via new getter functions, which
+- * are unfortunately not available in earlier versions. We define
+- * below those getter functions as macros for use when building
+- * against earlier CUPS versions.
+- */
+-#ifndef HAVE_CUPS_API_1_6
+-#define ippGetOperation(ipp_request) ipp_request->request.op.operation_id
+-#define ippGetInteger(attr, index) attr->values[index].integer
+-#define ippGetBoolean(attr, index) attr->values[index].boolean
+-#define ippGetString(attr, index, foo) attr->values[index].string.text
+-#define ippGetValueTag(attr) attr->value_tag
+-#define ippGetName(attr) attr->name
+-#define ippGetCount(attr) attr->num_values
+-#define ippGetGroupTag(attr) attr->group_tag
+-
+-static int
+-ippGetRange (ipp_attribute_t *attr,
+-             int element,
+-             int *upper)
+-{
+-  *upper = attr->values[element].range.upper;
+-  return (attr->values[element].range.lower);
+-}
+-#endif
+ /*
+  * GtkPrintBackendCups
+  */
+@@ -898,40 +873,6 @@ is_address_local (const gchar *address)
+     return FALSE;
+ }
+ 
+-#ifndef HAVE_CUPS_API_1_2
+-/* Included from CUPS library because of backward compatibility */
+-const char *
+-httpGetHostname(http_t *http,
+-                char   *s,
+-                int    slen)
+-{
+-  struct hostent *host;
+-
+-  if (!s || slen <= 1)
+-    return (NULL);
+-
+-  if (http)
+-    {
+-      if (http->hostname[0] == '/')
+-        g_strlcpy (s, "localhost", slen);
+-      else
+-        g_strlcpy (s, http->hostname, slen);
+-    }
+-  else
+-    {
+-      if (gethostname (s, slen) < 0)
+-        g_strlcpy (s, "localhost", slen);
+-
+-      if (!strchr (s, '.'))
+-        {
+-          if ((host = gethostbyname (s)) != NULL && host->h_name)
+-            g_strlcpy (s, host->h_name, slen);
+-        }
+-    }
+-  return (s);
+-}
+-#endif
+-
+ static void
+ gtk_print_backend_cups_set_password (GtkPrintBackend  *backend,
+                                      gchar           **auth_info_required,
+@@ -1168,11 +1109,7 @@ cups_dispatch_add_poll (GSource *source)
+ 	  else
+ 	    dispatch->data_poll->events = 0;
+ 
+-#ifdef HAVE_CUPS_API_1_2
+           dispatch->data_poll->fd = httpGetFd (dispatch->request->http);
+-#else
+-          dispatch->data_poll->fd = dispatch->request->http->fd;
+-#endif
+           g_source_add_poll (source, dispatch->data_poll);
+         }
+     }
+@@ -1698,18 +1635,8 @@ cups_request_job_info_cb (GtkPrintBackendCups *print_backend,
+ 
+   state = 0;
+ 
+-#ifdef HAVE_CUPS_API_1_6
+   attr = ippFindAttribute (response, "job-state", IPP_TAG_ENUM);
+   state = ippGetInteger (attr, 0);
+-#else
+-  for (attr = response->attrs; attr != NULL; attr = attr->next) 
+-    {
+-      if (!attr->name)
+-        continue;
+-      
+-      _CUPS_MAP_ATTR_INT (attr, state, "job-state");
+-    }
+-#endif
+ 
+   done = FALSE;
+   switch (state)
+@@ -3036,7 +2963,7 @@ cups_request_printer_list_cb (GtkPrintBackendCups *cups_backend,
+   removed_printer_checklist = gtk_print_backend_get_printer_list (backend);
+ 								  
+   response = gtk_cups_result_get_response (result);
+-#ifdef HAVE_CUPS_API_1_6
++
+   for (attr = ippFirstAttribute (response); attr != NULL;
+        attr = ippNextAttribute (response))
+     {
+@@ -3057,27 +2984,6 @@ cups_request_printer_list_cb (GtkPrintBackendCups *cups_backend,
+ 	cups_printer_handle_attribute (cups_backend, attr, info);
+         attr = ippNextAttribute (response);
+       }
+-#else
+-  for (attr = response->attrs; attr != NULL; attr = attr->next)
+-    {
+-      GtkPrinter *printer;
+-      gboolean status_changed = FALSE;
+-      GList *node;
+-      PrinterSetupInfo *info = g_slice_new0 (PrinterSetupInfo);
+-
+-      /* Skip leading attributes until we hit a printer...
+-       */
+-      while (attr != NULL && ippGetGroupTag (attr) != IPP_TAG_PRINTER)
+-        attr = attr->next;
+-
+-      if (attr == NULL)
+-        break;
+-      while (attr != NULL && ippGetGroupTag (attr) == IPP_TAG_PRINTER)
+-      {
+-	cups_printer_handle_attribute (cups_backend, attr, info);
+-        attr = attr->next;
+-      }
+-#endif
+ 
+       if (info->printer_name == NULL ||
+ 	  (info->printer_uri == NULL && info->member_uris == NULL))

--- a/x11-libs/gtk+/gtk+-2.24.32-r3.ebuild
+++ b/x11-libs/gtk+/gtk+-2.24.32-r3.ebuild
@@ -171,9 +171,6 @@ src_prepare() {
 	# Upstream gtk-2-24 branch up to 2018-09-08 state, bug #650536 safety
 	eapply "${FILESDIR}"/patches
 
-	# Fix compilation with cups 2.x
-	eapply "${FILESDIR}"/${PN}-2.0-cups2.patch
-
 	eautoreconf
 	gnome3_src_prepare
 }


### PR DESCRIPTION
Automatic bump of package x11-libs/gtk+-2.24.32-r3 for branch mark-unstable by mark-bot