### PR TITLE
mark-devkit: [mark-unstable] Bump net-misc/rygel-0.40.4-r1

### DIFF
--- a/net-misc/rygel/rygel-0.40.4-r1.ebuild
+++ b/net-misc/rygel/rygel-0.40.4-r1.ebuild
@@ -38,7 +38,7 @@ RDEPEND="dev-libs/glib
 	  dev-libs/libunistring:=
 	  x11-libs/gdk-pixbuf:2
 	)
-	tracker? ( >=app-misc/tracker:= )
+	tracker? ( app-misc/tracker:= )
 	transcode? (
 	  media-libs/gst-plugins-bad:1.0
 	  media-plugins/gst-plugins-twolame:1.0


### PR DESCRIPTION
Automatic bump of package net-misc/rygel-0.40.4-r1 for branch mark-unstable by mark-bot