### PR TITLE
mark-devkit: [mark-iii] Bump dev-libs/atk-2.58.0

### DIFF
--- a/dev-libs/atk/atk-2.58.0.ebuild
+++ b/dev-libs/atk/atk-2.58.0.ebuild
@@ -1,0 +1,15 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+DESCRIPTION="GTK+ & Gnome Accessibility Toolkit Metadata"
+HOMEPAGE="https://wiki.gnome.org/Accessibility"
+SLOT="0"
+KEYWORDS="*"
+IUSE="+introspection"
+RDEPEND=">=app-accessibility/at-spi2-core-2.58.0[introspection?]
+	
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package dev-libs/atk-2.58.0 for branch mark-iii by mark-bot