### PR TITLE
mark-devkit: [mark-iii] Bump gnome-base/gconf-3.2.6-r8

### DIFF
--- a/gnome-base/gconf/gconf-3.2.6-r8.ebuild
+++ b/gnome-base/gconf/gconf-3.2.6-r8.ebuild
@@ -29,7 +29,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	dev-libs/libxslt
-	dev-util/glib-utils
 	dev-util/gtk-doc-am
 	>=dev-util/intltool-0.35
 	>=virtual/pkgconfig-0-r1


### PR DESCRIPTION
Automatic bump of package gnome-base/gconf-3.2.6-r8 for branch mark-iii by mark-bot