### PR TITLE
mark-devkit: [mark-iii] Bump net-libs/libaccounts-glib-1.24-r2

### DIFF
--- a/net-libs/libaccounts-glib/libaccounts-glib-1.24-r2.ebuild
+++ b/net-libs/libaccounts-glib/libaccounts-glib-1.24-r2.ebuild
@@ -28,7 +28,6 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	$(vala_depend)
 	dev-util/gdbus-codegen
-	dev-util/glib-utils
 	dev-libs/check
 	doc? ( dev-util/gtk-doc )
 "


### PR DESCRIPTION
Automatic bump of package net-libs/libaccounts-glib-1.24-r2 for branch mark-iii by mark-bot