### PR TITLE
mark-devkit: [mark-iii] Bump net-libs/telepathy-glib-0.24.1-r2

### DIFF
--- a/net-libs/telepathy-glib/telepathy-glib-0.24.1-r2.ebuild
+++ b/net-libs/telepathy-glib/telepathy-glib-0.24.1-r2.ebuild
@@ -31,7 +31,6 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
 	dev-libs/libxslt
-	dev-util/glib-utils
 	dev-util/gtk-doc-am
 	virtual/pkgconfig
 	vala? ( $(vala_depend) )


### PR DESCRIPTION
Automatic bump of package net-libs/telepathy-glib-0.24.1-r2 for branch mark-iii by mark-bot