### PR TITLE
mark-devkit: [mark-iii] Bump media-libs/grilo-0.3.14-r1

### DIFF
--- a/media-libs/grilo/grilo-0.3.14-r1.ebuild
+++ b/media-libs/grilo/grilo-0.3.14-r1.ebuild
@@ -31,7 +31,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
-	dev-util/glib-utils
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig
 	gtk-doc? (


### PR DESCRIPTION
Automatic bump of package media-libs/grilo-0.3.14-r1 for branch mark-iii by mark-bot