### PR TITLE
mark-devkit: [mark-iii] Bump x11-libs/goffice-0.10.59-r1

### DIFF
--- a/x11-libs/goffice/goffice-0.10.59-r1.ebuild
+++ b/x11-libs/goffice/goffice-0.10.59-r1.ebuild
@@ -34,7 +34,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	dev-lang/perl
-	dev-util/glib-utils
 	>=dev-util/gtk-doc-am-1.32
 	>=dev-util/intltool-0.51
 	virtual/perl-Compress-Raw-Zlib


### PR DESCRIPTION
Automatic bump of package x11-libs/goffice-0.10.59-r1 for branch mark-iii by mark-bot