### PR TITLE
mark-devkit: [mark-unstable] Bump dev-libs/libgnome-games-support-2.0.2

### DIFF
--- a/dev-libs/libgnome-games-support/libgnome-games-support-2.0.2.ebuild
+++ b/dev-libs/libgnome-games-support/libgnome-games-support-2.0.2.ebuild
@@ -1,0 +1,32 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+inherit gnome3 meson vala
+
+DESCRIPTION="Library for code common to GNOME games"
+HOMEPAGE="https://gitlab.gnome.org/GNOME/libgnome-games-support"
+SRC_URI="https://download.gnome.org/sources/libgnome-games-support/2.0/libgnome-games-support-2.0.2.tar.xz -> libgnome-games-support-2.0.2.tar.xz"
+LICENSE="LGPL-3+"
+SLOT="2"
+KEYWORDS="*"
+BDEPEND="sys-devel/gettext
+	virtual/pkgconfig
+	$(vala_depend)
+	
+"
+RDEPEND="dev-libs/libgee:=
+	dev-libs/glib:2
+	x11-libs/gtk+:3
+	
+"
+DEPEND="${RDEPEND}
+"
+src_prepare() {
+	default
+	vala_src_prepare
+	gnome3_src_prepare
+}
+
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package dev-libs/libgnome-games-support-2.0.2 for branch mark-unstable by mark-bot