### PR TITLE
mark-devkit: [mark-iii] Bump gnome-extra/sushi-46.0-r1

### DIFF
--- a/gnome-extra/sushi/sushi-46.0-r1.ebuild
+++ b/gnome-extra/sushi/sushi-46.0-r1.ebuild
@@ -17,9 +17,7 @@ CDEPEND="media-libs/libepoxy
 	papers? (
 	  app-text/papers
 	)
-	!papers? (
-	  app-text/evince[introspection]
-	)
+	app-text/evince[introspection]
 	media-libs/freetype
 	x11-libs/gdk-pixbuf[introspection]
 	dev-libs/glib:2


### PR DESCRIPTION
Automatic bump of package gnome-extra/sushi-46.0-r1 for branch mark-iii by mark-bot