### PR TITLE
mark-devkit: [mark-iii] Bump x11-libs/gtk+-3.24.51-r1

### DIFF
--- a/x11-libs/gtk+/gtk+-3.24.51-r1.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.51-r1.ebuild
@@ -59,7 +59,6 @@ BDEPEND="app-text/docbook-xml-dtd:4.1.2
 	dev-libs/gobject-introspection-common
 	dev-libs/libxslt
 	>=dev-util/gdbus-codegen-2.48
-	dev-util/glib-utils
 	dev-util/gtk-doc-am
 	wayland? ( dev-util/wayland-scanner )
 	sys-devel/gettext


### PR DESCRIPTION
Automatic bump of package x11-libs/gtk+-3.24.51-r1 for branch mark-iii by mark-bot