### PR TITLE
mark-devkit: [mark-iii] Bump app-accessibility/at-spi2-atk-2.46.0-r1

### DIFF
--- a/app-accessibility/at-spi2-atk/at-spi2-atk-2.46.0-r1.ebuild
+++ b/app-accessibility/at-spi2-atk/at-spi2-atk-2.46.0-r1.ebuild
@@ -7,7 +7,7 @@ DESCRIPTION="Gtk module for bridging AT-SPI to Atk Metadata"
 HOMEPAGE="https://wiki.gnome.org/Accessibility"
 SLOT="2"
 KEYWORDS="*"
-RDEPEND=">=app-accessibility/at-spi2-core-2.46.0
+PDEPEND=">=app-accessibility/at-spi2-core-2.46.0
 	
 "
 


### PR DESCRIPTION
Automatic bump of package app-accessibility/at-spi2-atk-2.46.0-r1 for branch mark-iii by mark-bot