### PR TITLE
mark-devkit: [mark-iii] Bump gnome-extra/evolution-data-server-3.58.2-r1

### DIFF
--- a/gnome-extra/evolution-data-server/evolution-data-server-3.58.2-r1.ebuild
+++ b/gnome-extra/evolution-data-server/evolution-data-server-3.58.2-r1.ebuild
@@ -70,6 +70,11 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	use vala && vala_src_prepare
 	cmake_src_prepare
+	# Make CMakeLists versioned vala enabled
+	sed -e "s;\(find_program(VALAC\) valac);\1 ${VALAC});" \
+	  -e "s;\(find_program(VAPIGEN\) vapigen);\1 ${VAPIGEN});" \
+	  -i "${S}"/CMakeLists.txt || die
+
 }
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
Automatic bump of package gnome-extra/evolution-data-server-3.58.2-r1 for branch mark-iii by mark-bot