### PR TITLE
mark-devkit: [mark-iii] Bump media-video/cheese-44.1-r2

### DIFF
--- a/media-video/cheese/cheese-44.1-r2.ebuild
+++ b/media-video/cheese/cheese-44.1-r2.ebuild
@@ -65,6 +65,7 @@ src_configure() {
 	for video in /dev/video* ; do
 	  addpredict "${video}"
 	done
+	addpredict /proc/self/task
 	local emesonargs=(
 	  $(meson_use introspection)
 	  -Dtests=false


### PR DESCRIPTION
Automatic bump of package media-video/cheese-44.1-r2 for branch mark-iii by mark-bot