### PR TITLE
mark-devkit: [mark-iii] Bump media-video/totem-43.2-r1

### DIFF
--- a/media-video/totem/totem-43.2-r1.ebuild
+++ b/media-video/totem/totem-43.2-r1.ebuild
@@ -76,7 +76,7 @@ src_prepare() {
 }
 src_configure() {
 	# work around sandbox violation
-	for card in /dev/dri/card* ; do
+	for card in /dev/dri/{card,render}* ; do
 	  addpredict "${card}"
 	done
 	addpredict /proc/self/task


### PR DESCRIPTION
Automatic bump of package media-video/totem-43.2-r1 for branch mark-iii by mark-bot