### PR TITLE
mark-devkit: [mark-31] Bump media-libs/clutter-1.26.4-r1

### DIFF
--- a/media-libs/clutter/clutter-1.26.4-r1.ebuild
+++ b/media-libs/clutter/clutter-1.26.4-r1.ebuild
@@ -11,9 +11,9 @@ DESCRIPTION="Clutter is a library for creating graphical user interfaces"
 LICENSE="LGPL-2.1+ FDL-1.1+"
 SLOT="1.0"
 
-IUSE="aqua debug doc egl gtk +introspection test wayland X"
+IUSE="debug doc egl gtk +introspection wayland X"
 REQUIRED_USE="
-	|| ( aqua wayland X )
+	|| ( wayland X )
 	wayland? ( egl )
 "
 
@@ -27,7 +27,7 @@ RDEPEND="
 	>=dev-libs/atk-2.5.3[introspection?]
 	>=dev-libs/json-glib-0.12[introspection?]
 	>=media-libs/cogl-1.21.2:1.0=[introspection?,pango]
-	>=x11-libs/cairo-1.16.0:=[aqua?,glib]
+	>=x11-libs/cairo-1.16.0:=[glib]
 	>=x11-libs/pango-1.44.7[introspection?]
 
 	virtual/opengl
@@ -39,14 +39,13 @@ RDEPEND="
 		>=virtual/libgudev-136
 		x11-libs/libxkbcommon
 	)
-	gtk? ( >=x11-libs/gtk+-3.24.12:3[aqua?] )
-	introspection? ( >=dev-libs/gobject-introspection-1.62.0:= )
+	gtk? ( x11-libs/gtk+:3 )
+	introspection? ( dev-libs/gobject-introspection:= )
 	X? (
 		media-libs/fontconfig
-		>=x11-libs/libX11-1.3.1
+		x11-libs/libX11
 		x11-libs/libXext
 		x11-libs/libXdamage
-		x11-proto/inputproto
 		>=x11-libs/libXi-1.3
 		>=x11-libs/libXcomposite-0.4 )
 	wayland? (
@@ -55,6 +54,7 @@ RDEPEND="
 		x11-libs/gdk-pixbuf:2 )
 "
 DEPEND="${RDEPEND}
+	x11-base/xorg-proto
 	>=dev-util/gtk-doc-am-1.20
 	>=sys-devel/gettext-0.17
 	virtual/pkgconfig
@@ -97,7 +97,7 @@ src_configure() {
 		--disable-cex100-backend \
 		--disable-win32-backend \
 		--disable-tslib-input \
-		$(use_enable aqua quartz-backend) \
+		--disable-disable-quartz-backend \
 		$(usex debug --enable-debug=yes --enable-debug=minimum) \
 		$(use_enable doc docs) \
 		$(use_enable egl egl-backend) \
@@ -109,8 +109,4 @@ src_configure() {
 		$(use_enable wayland wayland-compositor) \
 		$(use_enable X xinput) \
 		$(use_enable X x11-backend)
-}
-
-src_test() {
-	virtx emake check -C tests/conform
 }


### PR DESCRIPTION
Automatic bump of package media-libs/clutter-1.26.4-r1 for branch mark-31 by mark-bot