### PR TITLE
mark-devkit: [mark-31] Bump app-misc/tracker-miners-2.3.5-r1

### DIFF
--- a/app-misc/tracker-miners/tracker-miners-2.3.5-r1.ebuild
+++ b/app-misc/tracker-miners/tracker-miners-2.3.5-r1.ebuild
@@ -56,7 +56,6 @@ RDEPEND="
 	app-arch/gzip
 "
 DEPEND="${RDEPEND}
-	dev-util/glib-utils
 
 	>=dev-util/intltool-0.40.0
 	>=sys-devel/gettext-0.19.8


### PR DESCRIPTION
Automatic bump of package app-misc/tracker-miners-2.3.5-r1 for branch mark-31 by mark-bot