### PR TITLE
mark-devkit: [mark-31] Bump net-im/telepathy-logger-0.8.2-r2

### DIFF
--- a/net-im/telepathy-logger/telepathy-logger-0.8.2-r2.ebuild
+++ b/net-im/telepathy-logger/telepathy-logger-0.8.2-r2.ebuild
@@ -30,7 +30,6 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="
 	${PYTHON_DEPS}
-	dev-util/glib-utils
 	>=dev-util/gtk-doc-am-1.10
 	>=dev-util/intltool-0.35
 	virtual/pkgconfig


### PR DESCRIPTION
Automatic bump of package net-im/telepathy-logger-0.8.2-r2 for branch mark-31 by mark-bot