### PR TITLE
mark-devkit: [mark-31] Bump virtual/libgudev-238

### DIFF
--- a/virtual/libgudev/libgudev-238.ebuild
+++ b/virtual/libgudev/libgudev-238.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+DESCRIPTION="Virtual for libgudev providers"
+SLOT="0"
+KEYWORDS="*"
+IUSE="introspection"
+RDEPEND=">=dev-libs/libgudev-238[introspection?]
+	
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/libgudev-238 for branch mark-31 by mark-bot