### PR TITLE
mark-devkit: [mark-31] Bump app-misc/tracker-2.3.6-r1

### DIFF
--- a/app-misc/tracker/tracker-2.3.6-r1.ebuild
+++ b/app-misc/tracker/tracker-2.3.6-r1.ebuild
@@ -31,7 +31,6 @@ RDEPEND="
 	sys-apps/util-linux
 "
 DEPEND="${RDEPEND}
-	dev-util/glib-utils
 	>=dev-util/intltool-0.40.0
 	$(vala_depend)
 	gtk-doc? ( >=dev-util/gtk-doc-1.8


### PR DESCRIPTION
Automatic bump of package app-misc/tracker-2.3.6-r1 for branch mark-31 by mark-bot