### PR TITLE
mark-devkit: [mark-31] Bump net-libs/gtk-vnc-1.3.1-r1

### DIFF
--- a/net-libs/gtk-vnc/gtk-vnc-1.3.1-r1.ebuild
+++ b/net-libs/gtk-vnc/gtk-vnc-1.3.1-r1.ebuild
@@ -35,7 +35,6 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	${PYTHON_DEPS}
 	>=dev-lang/perl-5
-	dev-util/glib-utils
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig
 	vala? ( $(vala_depend) )


### PR DESCRIPTION
Automatic bump of package net-libs/gtk-vnc-1.3.1-r1 for branch mark-31 by mark-bot