### PR TITLE
mark-devkit: [mark-31] Bump net-libs/libsoup-2.74.0-r1

### DIFF
--- a/net-libs/libsoup/libsoup-2.74.0-r1.ebuild
+++ b/net-libs/libsoup/libsoup-2.74.0-r1.ebuild
@@ -33,7 +33,6 @@ RDEPEND="${DEPEND}
 "
 BDEPEND="
 	dev-libs/glib
-	dev-util/glib-utils
 	gtk-doc? ( >=dev-util/gtk-doc-1.20
 		app-text/docbook-xml-dtd:4.1.2 )
 	>=sys-devel/gettext-0.19.8


### PR DESCRIPTION
Automatic bump of package net-libs/libsoup-2.74.0-r1 for branch mark-31 by mark-bot