### PR TITLE
mark-devkit: [mark-31] Bump dev-cpp/atkmm-2.28.4-r1

### DIFF
--- a/dev-cpp/atkmm/atkmm-2.28.4-r1.ebuild
+++ b/dev-cpp/atkmm/atkmm-2.28.4-r1.ebuild
@@ -15,7 +15,7 @@ IUSE="gtk-doc"
 BDEPEND="virtual/pkgconfig
 	gtk-doc? (
 	  dev-cpp/mm-common
-	  app-text/doxygen[dot]
+	  app-doc/doxygen[dot]
 	  dev-libs/libxslt
 	)
 	${PYTHON_DEPS}


### PR DESCRIPTION
Automatic bump of package dev-cpp/atkmm-2.28.4-r1 for branch mark-31 by mark-bot