### PR TITLE
mark-devkit: [mark-31] Bump dev-cpp/cairomm-1.19.0-r1

### DIFF
--- a/dev-cpp/cairomm/cairomm-1.19.0-r1.ebuild
+++ b/dev-cpp/cairomm/cairomm-1.19.0-r1.ebuild
@@ -16,7 +16,7 @@ BDEPEND="virtual/pkgconfig
 	gtk-doc? (
 	  ${PYTHON_DEPS}
 	  dev-cpp/mm-common
-	  app-text/doxygen[dot]
+	  app-doc/doxygen[dot]
 	  dev-libs/libxslt
 	)
 	


### PR DESCRIPTION
Automatic bump of package dev-cpp/cairomm-1.19.0-r1 for branch mark-31 by mark-bot