### PR TITLE
mark-devkit: [mark-31] Bump dev-cpp/gtkmm-3.24.10-r2

### DIFF
--- a/dev-cpp/gtkmm/gtkmm-3.24.10-r2.ebuild
+++ b/dev-cpp/gtkmm/gtkmm-3.24.10-r2.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="*"
 IUSE="gtk-doc wayland X"
 BDEPEND="virtual/pkgconfig
 	gtk-doc? (
-	  app-text/doxygen[dot]
+	  app-doc/doxygen[dot]
 	  dev-lang/perl
 	  dev-libs/libxslt
 	)


### PR DESCRIPTION
Automatic bump of package dev-cpp/gtkmm-3.24.10-r2 for branch mark-31 by mark-bot