### PR TITLE
mark-devkit: [mark-31] Bump dev-cpp/gtkmm-4.21.2-r1

### DIFF
--- a/dev-cpp/gtkmm/gtkmm-4.21.2-r1.ebuild
+++ b/dev-cpp/gtkmm/gtkmm-4.21.2-r1.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="*"
 IUSE="gtk-doc"
 BDEPEND="virtual/pkgconfig
 	gtk-doc? (
-	  app-text/doxygen[dot]
+	  app-doc/doxygen[dot]
 	  dev-lang/perl
 	  dev-libs/libxslt
 	)


### PR DESCRIPTION
Automatic bump of package dev-cpp/gtkmm-4.21.2-r1 for branch mark-31 by mark-bot