### PR TITLE
mark-devkit: [mark-31] Bump dev-cpp/glibmm-2.86.0-r1

### DIFF
--- a/dev-cpp/glibmm/glibmm-2.86.0-r1.ebuild
+++ b/dev-cpp/glibmm/glibmm-2.86.0-r1.ebuild
@@ -15,7 +15,7 @@ IUSE="gtk-doc debug"
 BDEPEND="${PYTHON_DEPS}
 	virtual/pkgconfig
 	gtk-doc? (
-	  app-text/doxygen
+	  app-doc/doxygen
 	  dev-lang/perl
 	  dev-libs/libxslt
 	)


### PR DESCRIPTION
Automatic bump of package dev-cpp/glibmm-2.86.0-r1 for branch mark-31 by mark-bot