### PR TITLE
mark-devkit: [mark-31] Bump dev-cpp/gtkmm-2.24.5-r3

### DIFF
--- a/dev-cpp/gtkmm/gtkmm-2.24.5-r3.ebuild
+++ b/dev-cpp/gtkmm/gtkmm-2.24.5-r3.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="*"
 IUSE="gtk-doc examples"
 BDEPEND="virtual/pkgconfig
 	gtk-doc? (
-	  app-text/doxygen[dot]
+	  app-doc/doxygen[dot]
 	  media-gfx/graphviz
 	  dev-libs/libxslt
 	  dev-lang/perl


### PR DESCRIPTION
Automatic bump of package dev-cpp/gtkmm-2.24.5-r3 for branch mark-31 by mark-bot