### PR TITLE
mark-devkit: [mark-31] Bump dev-libs/librevenge-0.0.5-r1

### DIFF
--- a/dev-libs/librevenge/librevenge-0.0.5-r1.ebuild
+++ b/dev-libs/librevenge/librevenge-0.0.5-r1.ebuild
@@ -10,7 +10,7 @@ LICENSE="LGPL-2.1-or-later OR MPL-2.0"
 SLOT="0"
 KEYWORDS="*"
 IUSE="doc"
-BDEPEND="doc? ( app-text/doxygen[dot] )
+BDEPEND="doc? ( app-doc/doxygen[dot] )
 	
 "
 RDEPEND="sys-libs/zlib


### PR DESCRIPTION
Automatic bump of package dev-libs/librevenge-0.0.5-r1 for branch mark-31 by mark-bot