### PR TITLE
mark-devkit: [mark-31] Bump gnome-base/librsvg-2.61.3-r1

### DIFF
--- a/gnome-base/librsvg/librsvg-2.61.3-r1.ebuild
+++ b/gnome-base/librsvg/librsvg-2.61.3-r1.ebuild
@@ -57,6 +57,10 @@ src_configure() {
 }
 src_install() {
 	meson_src_install
+	# See mark-issues/issues#579
+	# Add link to fix upstream bug
+	dosym /usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader_svg.so \
+		/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so
 }
 pkg_postinst() {
 	# causes segfault if set, see bug 375615


### PR DESCRIPTION
Automatic bump of package gnome-base/librsvg-2.61.3-r1 for branch mark-31 by mark-bot