### PR TITLE
mark-devkit: [mark-iii] Bump media-libs/libglycin-2.0.7-r1

### DIFF
--- a/media-libs/libglycin/libglycin-2.0.7-r1.ebuild
+++ b/media-libs/libglycin/libglycin-2.0.7-r1.ebuild
@@ -26,6 +26,7 @@ IUSE="heif jpeg2k jpegxl svg debug +vala gtk4"
 RDEPEND="dev-libs/glib:2
 	sys-libs/libseccomp
 	heif? ( >=media-libs/libheif-1.17.0:= )
+	media-libs/lcms
 "
 PDEPEND="
 	jpegxl? ( media-libs/libjxl:= )


### PR DESCRIPTION
Automatic bump of package media-libs/libglycin-2.0.7-r1 for branch mark-iii by mark-bot